### PR TITLE
Error handling while loading types from assembly

### DIFF
--- a/src/RouteJs.Mvc4/MvcRouteFilter.cs
+++ b/src/RouteJs.Mvc4/MvcRouteFilter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Web.Mvc;
 using System.Web.Routing;
 using System.Linq;
+using System.Reflection;
 
 namespace RouteJs.Mvc
 {
@@ -61,7 +62,7 @@ namespace RouteJs.Mvc
 		{
 			// Get all the controllers from all loaded assemblies
 			var controllers = AppDomain.CurrentDomain.GetAssemblies()
-				.SelectMany(assembly => assembly.GetTypes())
+				.SelectMany(GetTypesFromAssembly)
 				.Where(type => type.IsSubclassOf(typeof(Controller)))
 				.ToList();
 
@@ -79,6 +80,18 @@ namespace RouteJs.Mvc
 				{
 					_areaWhitelist.Add(_areaNamespaceMapping[areaKey]);
 				}
+			}
+		}
+		
+		private IEnumerable<Type> GetTypesFromAssembly(Assembly assembly)
+		{
+			try
+			{
+				return assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException)
+			{
+				return new Type[] { };
 			}
 		}
 


### PR DESCRIPTION
Some assemblies on our project gives us a headache while it comes to loading types from assemblies in the appdomain. Actually only one does, PdfSharp. You may list PdfSharp's assembly from the appdomain, but once you call assembly.GetTypes() on it, it throws a `ReflectionTypeLoadException`. We're trying to see why it is like that, but in the mean time I think it simply makes RouteJs a tiny bit more robust anyways, so I'm submitting this fix. 

I am not including a test for this fix, since I have no idea how to reproduce it without adding a dependency to a faulty assembly (and I'm not sure how to reproduce that). 

Here is the complete error we had, I tried to translate the relevant parts : 

```
RouteJs.TinyIoc.TinyIoCResolutionException: Unable to resolve type: RouteJs.Mvc.MvcRouteFilter ---> System.Reflection.TargetInvocationException: An exception was throw by the target. ---> System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the required types. See the LoaderExceptions property for more information.
   à System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   à System.Reflection.RuntimeModule.GetTypes()
   à System.Reflection.Assembly.GetTypes()
   à RouteJs.Mvc.MvcRouteFilter.<BuildLists>b__0(Assembly assembly)
   à System.Linq.Enumerable.<SelectManyIterator>d__14`2.MoveNext()
   à System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   à System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   à System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   à RouteJs.Mvc.MvcRouteFilter.BuildLists()
```
