### PR TITLE
Add missing configuration property + other stuff for the `LowerCaseUrls` option

### DIFF
--- a/src/RouteJs.AspNet/RouteJs.cs
+++ b/src/RouteJs.AspNet/RouteJs.cs
@@ -25,6 +25,8 @@ namespace RouteJs
 		/// </summary>
 		private readonly IEnumerable<IRouteFilter> _routeFilters;
 
+		private readonly IRouteJsConfiguration _routeJsConfiguration;
+
 		/// <summary>
 		/// Context object for the current request.
 		/// </summary>
@@ -33,12 +35,14 @@ namespace RouteJs
 		public RouteJs(
 			IEnumerable<IRouteFetcher> routeFetchers,
 			IActionContextAccessor actionContextAccessor,
-			IEnumerable<IRouteFilter> routeFilters
+			IEnumerable<IRouteFilter> routeFilters,
+			IRouteJsConfiguration routeJsConfiguration
 		)
 		{
 			_routeFetchers = routeFetchers;
 			_routeFilters = routeFilters;
 			_actionContext = actionContextAccessor.ActionContext;
+			_routeJsConfiguration = routeJsConfiguration;
 		}
 
 		/// <summary>
@@ -72,6 +76,7 @@ namespace RouteJs
 			{
 				Routes = routes,
 				BaseUrl = _actionContext.HttpContext.Request.PathBase.Value,
+				LowerCaseUrls = _routeJsConfiguration.LowerCaseUrls,
 			};
 			var jsonRoutes = JsonConvert.SerializeObject(settings, new JsonSerializerSettings
 			{

--- a/src/RouteJs.AspNet/ServiceExtensions.cs
+++ b/src/RouteJs.AspNet/ServiceExtensions.cs
@@ -7,26 +7,26 @@ namespace RouteJs
 	/// <summary>
 	/// RouteJs extensions to <see cref="IServiceCollection"/>.
 	/// </summary>
-    public static class ServiceExtensions
-    {
+	public static class ServiceExtensions
+	{
 		/// <summary>
 		/// Installs RouteJs services for this website.
 		/// </summary>
 		/// <param name="services">Service collection to register routes in</param>
 		/// <returns>The service collection</returns>
-	    public static IServiceCollection AddRouteJs(this IServiceCollection services)
-	    {
+		public static IServiceCollection AddRouteJs(this IServiceCollection services)
+		{
 			services.AddSingleton<IRouteJsConfiguration>(provider => provider.GetRequiredService<IOptions<RouteJsConfiguration>>().Options);
 			services.AddSingleton<IRouteFetcher, TemplateRouteFetcher>();
-		    services.AddSingleton<IRouteFetcher, AttributeRouteFetcher>();
+			services.AddSingleton<IRouteFetcher, AttributeRouteFetcher>();
 			services.AddSingleton<IConstraintsProcessor, ConstraintsProcessor>();
 			services.AddSingleton<IRouteTemplateParser, RouteTemplateParser>();
 			services.AddSingleton<IRouteFilter, DefaultRouteFilter>();
 			services.AddScoped<IRouteJsHelper, RouteJsHelper>();
 			services.AddScoped<IRouteJs, RouteJs>();
-			
-		    return services;
-	    }
+
+			return services;
+		}
 
 		/// <summary>
 		/// Configures RouteJs for this site.
@@ -38,5 +38,5 @@ namespace RouteJs
 		{
 			return services.Configure(configure);
 		}
-    }
+	}
 }

--- a/src/RouteJs.Tests.AspNet/RouteJsTests.cs
+++ b/src/RouteJs.Tests.AspNet/RouteJsTests.cs
@@ -11,8 +11,8 @@ namespace RouteJs.Tests.AspNet
 	/// <summary>
 	/// Unit tests for <see cref="RouteJs" />.
 	/// </summary>
-    public class RouteJsTests
-    {
+	public class RouteJsTests
+	{
 		[Fact]
 		public void GetsRoutesFromRouteFetcher()
 		{
@@ -42,11 +42,12 @@ namespace RouteJs.Tests.AspNet
 			{
 				HttpContext = httpContext.Object
 			});
+			var config = new Mock<IRouteJsConfiguration>();
 
-			var routeJs = new RouteJs(new[] { routeFetcher.Object }, actionContext.Object, Enumerable.Empty<IRouteFilter>());
+			var routeJs = new RouteJs(new[] { routeFetcher.Object }, actionContext.Object, Enumerable.Empty<IRouteFilter>(), config.Object);
 			var result = routeJs.GetJsonData();
-			const string expected = @"{""routes"":[{""url"":""foo/bar"",""defaults"":{""controller"":""Foo"",""action"":""Bar""},""constraints"":{""constr"":""aint""},""optional"":[""id""]}],""baseUrl"":""/base""}";
+			const string expected = @"{""routes"":[{""url"":""foo/bar"",""defaults"":{""controller"":""Foo"",""action"":""Bar""},""constraints"":{""constr"":""aint""},""optional"":[""id""]}],""baseUrl"":""/base"",""lowerCaseUrls"":false}";
 			Assert.Equal(expected, result);
 		}
-    }
+	}
 }

--- a/src/RouteJs.Tests.Mvc4/MvcRouteTests.cs
+++ b/src/RouteJs.Tests.Mvc4/MvcRouteTests.cs
@@ -70,24 +70,5 @@ namespace RouteJs.Tests.Mvc
 			Assert.AreEqual("HelloWorld", result[0].Defaults["action"]);
 			Assert.AreEqual("TestArea", result[0].Defaults["area"]);
 		}
-
-		[Test]
-		public void HandlesLowerCaseUrls()
-		{
-			var routes = new RouteCollection();
-			routes.MapRoute(
-				name: "Hello",
-				url: "Hello/World",
-				defaults: new { controller = "Hello", action = "Hello-World" }
-			);
-			var routeJs = CreateRouteJs(routes, lowerCaseUrls: true);
-
-			var result = routeJs.GetRoutes().ToList();
-
-			Assert.AreEqual(1, result.Count);
-			Assert.AreEqual("hello/world", result[0].Url);
-			Assert.AreEqual("hello", result[0].Defaults["controller"]);
-			Assert.AreEqual("hello-world", result[0].Defaults["action"]);
-		}
 	}
 }

--- a/src/RouteJs/RouteJsConfigurationSection.cs
+++ b/src/RouteJs/RouteJsConfigurationSection.cs
@@ -25,6 +25,7 @@ namespace RouteJs
 		/// If <c>true</c>, urls will be converted to lowercase.
 		/// If <c>false</c>, urls will remain the same.
 		/// </summary>
+		[ConfigurationProperty("lowerCaseUrls", DefaultValue = false)]
 		public bool LowerCaseUrls
 		{
 			get { return (bool)this["lowerCaseUrls"]; }

--- a/src/RouteJs/RouteJsHandler.cs
+++ b/src/RouteJs/RouteJsHandler.cs
@@ -150,11 +150,13 @@ namespace RouteJs
 		private static string GetJsonData()
 		{
 			var router = ComponentRegistration.Container.Resolve<RouteJs>();
+			var config = ComponentRegistration.Container.Resolve<IRouteJsConfiguration>();
 			var routes = router.GetRoutes();
 			var settings = new
 			{
 				Routes = routes,
-				BaseUrl = VirtualPathUtility.ToAbsolute("~/")
+				BaseUrl = VirtualPathUtility.ToAbsolute("~/"),
+				LowerCaseUrls = config.LowerCaseUrls,
 			};
 			var jsonRoutes = JsonConvert.SerializeObject(settings, new JsonSerializerSettings
 			{


### PR DESCRIPTION
- [x] Fix `lowerCaseUrls` unrecognized in web.config
- [x] Add support for AspNet 5
- [x] Reuse things as much as possible
- [x] Fix: "Articles/{key}/Edit" is being converted to "articles/{key}/Edit"
- [x] Add tests to cover these cases
- [x] Make the lowercase option reachable from javascript, so that we can generate lowercase urls for default routes (a default route is still generated as normal)
- [x] Convert all the things from js

Fixes #45 