### PR TITLE
Don't invoke the RouteJs.Tests.AspNet tests twice

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,5 @@ build:
   verbosity: normal
 test_script:
 - nunit-console.exe bin\ReleaseTests\RouteJs\RouteJs.Tests.dll bin\ReleaseTests\RouteJs.Mvc5\RouteJs.Tests.Mvc5.dll bin\ReleaseTests\RouteJs.Mvc4\RouteJs.Tests.Mvc4.dll bin\ReleaseTests\RouteJs.Mvc3\RouteJs.Tests.Mvc3.dll bin\ReleaseTests\RouteJs.Mvc2\RouteJs.Tests.Mvc2.dll
-- dnx --project src\RouteJs.Tests.AspNet test
 artifacts:
 - path: output\*.nupkg


### PR DESCRIPTION
This is something I also faced once.

I noticed that in addition to specifying the test in `build.proj` you're also invoking the same test in `appveyor.yml`. AppVeyor doesn't need the `test_script` section to collect tests, it collects them from your `build.proj` as well.

That's way it's collecting the same tests twice and you can see it clearly [here](https://ci.appveyor.com/project/Daniel15/routejs/build/70).