### PR TITLE
Use "/" by default if the baseUrl is empty

### DIFF
--- a/src/RouteJs.AspNet/RouteJs.cs
+++ b/src/RouteJs.AspNet/RouteJs.cs
@@ -73,10 +73,16 @@ namespace RouteJs
 				// Every filter must pass in order to use this route
 				.Where(route => _routeFilters.All(filter => filter.AllowRoute(route)));
 
+			var baseUrl = _actionContext.HttpContext.Request.PathBase.Value;
+			if (baseUrl.Length == 0 || baseUrl[0] != '/')
+			{
+				baseUrl = "/" + baseUrl;
+			}
+
 			var settings = new
 			{
 				Routes = routes,
-				BaseUrl = _actionContext.HttpContext.Request.PathBase.Value,
+				BaseUrl = baseUrl,
 				LowerCaseUrls = _routeJsConfiguration.LowerCaseUrls,
 			};
 			var jsonRoutes = JsonConvert.SerializeObject(settings, new JsonSerializerSettings

--- a/src/RouteJs.Tests.AspNet/RouteJsTests.cs
+++ b/src/RouteJs.Tests.AspNet/RouteJsTests.cs
@@ -1,10 +1,13 @@
 ﻿using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Infrastructure;
 using Microsoft.AspNet.Routing;
 using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Xunit;
 
 namespace RouteJs.Tests.AspNet
@@ -49,6 +52,44 @@ namespace RouteJs.Tests.AspNet
 			var result = routeJs.GetJsonData();
 			const string expected = @"{""routes"":[{""url"":""foo/bar"",""defaults"":{""controller"":""Foo"",""action"":""Bar""},""constraints"":{""constr"":""aint""},""optional"":[""id""]}],""baseUrl"":""/base"",""lowerCaseUrls"":false}";
 			Assert.Equal(expected, result);
+		}
+
+		[Fact]
+		public void InsertsSlashAtTheBeginningOfBaseUrl()
+		{
+			var routes = new[]
+				{
+				new RouteInfo
+				{
+					Constraints = new Dictionary<string, object> {{"constr", "aint"}},
+					Defaults = new Dictionary<string, object>
+					{
+						{"controller", "Foo"},
+						{"action", "Bar"}
+					},
+					Optional = new[] {"id"},
+					Url = "foo/bar",
+				},
+			};
+			var routeFetcher = new Mock<IRouteFetcher>();
+			routeFetcher.Setup(x => x.GetRoutes(It.IsAny<RouteData>())).Returns(routes);
+
+			var request = new Mock<HttpRequest>();
+			request.Setup(x => x.PathBase).Returns(new PathString(""));
+			var httpContext = new Mock<HttpContext>();
+			httpContext.Setup(x => x.Request).Returns(request.Object);
+			var actionContext = new Mock<IActionContextAccessor>();
+			actionContext.Setup(x => x.ActionContext).Returns(new ActionContext
+			{
+				HttpContext = httpContext.Object
+			});
+			var config = new Mock<IRouteJsConfiguration>();
+
+			var routeJs = new RouteJs(new[] { routeFetcher.Object }, actionContext.Object, Enumerable.Empty<IRouteFilter>(), config.Object);
+			var result = routeJs.GetJsonData();
+			dynamic json = JsonConvert.DeserializeObject<ExpandoObject>(result, new ExpandoObjectConverter());
+			const string expected = @"/";
+			Assert.Equal(expected, json.baseUrl);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #49 