### PR TITLE
Fixed issue with valid, zero-length routes

### DIFF
--- a/src/RouteJs.AspNet/router.js
+++ b/src/RouteJs.AspNet/router.js
@@ -306,7 +306,7 @@
 			
 			for (var i = 0, count = this.routes.length; i < count; i++) {
 				var url = this.routes[i].build(routeValues);
-				if (url) {
+				if (url != null) {
 					return this.baseUrl + url;
 				}
 			}


### PR DESCRIPTION
The `url` variable was falsey rejecting valid routes with zero-length (aka. empty strings). Checking for `null` instead of relying on falsey checking fixes the issue.